### PR TITLE
Fix warnings

### DIFF
--- a/src/ccid/CcidLocalAccess.c
+++ b/src/ccid/CcidLocalAccess.c
@@ -634,14 +634,6 @@ int CcidAesDec (int nSendLength, unsigned char* cSendData, int nReceiveLength, u
 
 u32 getRandomNumber (u32 Size_u32, u8 * Data_pu8)
 {
-u32 Ret_u32;
-
-u32 i;
-
-time_t now;
-
-static u8 FlasgTimeIsSet_u8 = FALSE;
-
     // Size ok ?
     if (APDU_MAX_RESPONSE_LEN <= Size_u32)
     {
@@ -649,9 +641,11 @@ static u8 FlasgTimeIsSet_u8 = FALSE;
     }
 
     // Get a random number from smartcard
-    Ret_u32 = CcidGetChallenge (Size_u32, Data_pu8);
+    // TODO: COMMENT FROM FLORIAN: IGNORE RETURN VALUE?
+    CcidGetChallenge (Size_u32, Data_pu8);
 
 #ifdef GENERATE_RANDOM_NUMBER_WITH_2ND_SOURCE
+    // TODO: COMMENT FROM FLORIAN: DOES THIS ACTUALLY ADD ENTROPY?
     // Paranoia: if the random number is not really random, xor it with
     // another random number from a second source
     if (FALSE == FlasgTimeIsSet_u8)
@@ -879,39 +873,14 @@ int getAID (void)
 
     InitSCTStruct (&tSCT);
 
-    unsigned short cRet;
-
     unsigned char nReturnSize;
 
     CcidSelectOpenPGPApp ();
-    cRet = CcidGetData (0x00, 0x4F, &nReturnSize);
+    // TODO: COMMENT FROM FLORIAN: IGNORE RETURN VALUE?
+    CcidGetData (0x00, 0x4F, &nReturnSize);
 
     return nReturnSize;
 }
-
-uint32_t getSerialNumber (void)
-{
-
-uint32_t serial;
-
-uint8_t buffer[4];
-
-    InitSCTStruct (&tSCT);
-
-unsigned short cRet;
-
-unsigned char nReturnSize;
-
-    CcidSelectOpenPGPApp ();
-    cRet = CcidGetData (0x00, 0x4F, &nReturnSize);
-
-
-
-    return 0;
-
-
-}
-
 
 uint8_t getByteOfData (uint8_t x)
 {
@@ -925,8 +894,6 @@ uint8_t cardAuthenticate (uint8_t * password)
     InitSCTStruct (&tSCT);
 
 unsigned short cRet;
-
-unsigned char nReturnSize;
 
     CcidSelectOpenPGPApp ();
     cRet = CcidVerifyPin (3, password);
@@ -945,8 +912,6 @@ uint8_t userAuthenticate (uint8_t * password)
     InitSCTStruct (&tSCT);
 
 unsigned short cRet;
-
-unsigned char nReturnSize;
 
     CcidSelectOpenPGPApp ();
     cRet = CcidVerifyPin (1, password);
@@ -1006,8 +971,6 @@ uint8_t changeUserPin (uint8_t * password, uint8_t * new_password)
 
 unsigned short cRet;
 
-unsigned char nReturnSize;
-
     CcidSelectOpenPGPApp ();
     cRet = CcidChangePin (1, password, new_password);
 
@@ -1025,8 +988,6 @@ uint8_t changeAdminPin (uint8_t * password, uint8_t * new_password)
     InitSCTStruct (&tSCT);
 
 unsigned short cRet;
-
-unsigned char nReturnSize;
 
     CcidSelectOpenPGPApp ();
     cRet = CcidChangePin (3, password, new_password);
@@ -1165,17 +1126,10 @@ unsigned char acBufferOut[32];
 
     nRet = CcidAesDec (nLen, pcKey, nLen, acBufferOut);
 
-    switch (nRet)
-    {
-        case APDU_ANSWER_COMMAND_CORRECT:
-            memcpy (pcKey, acBufferOut, nLen);
-            return TRUE;
-        case APDU_ANSWER_REF_DATA_NOT_FOUND:
-            memset (pcKey, 0, nLen);
-            return FALSE;
-        default:
-            nRet;
-    }
+    if (APDU_ANSWER_COMMAND_CORRECT == nRet)
+        return (TRUE);
+    else
+        return (FALSE);
     /*
        if (APDU_ANSWER_COMMAND_CORRECT == nRet) { //CI_LocalPrintf ("Decrypted AES key : "); //HexPrint (nLen,acBufferOut); //CI_LocalPrintf
        ("\r\n"); } else { memset (pcKey,0,nLen); //CI_LocalPrintf ("fail\n\r"); return (FALSE); }
@@ -1186,10 +1140,6 @@ unsigned char acBufferOut[32];
 uint8_t testSendUserPW2 (unsigned char* pcPW)
 {
     unsigned short nRet;
-
-    int n;
-
-    n = strlen ((char *) pcPW);
 
     // CI_LocalPrintf ("Send user password : ");
     nRet = CcidVerifyPin (2, pcPW);

--- a/src/ccid/smartcard/smartcard.c
+++ b/src/ccid/smartcard/smartcard.c
@@ -187,34 +187,6 @@ static void NVIC_Configuration (void)
 }
 
 /*******************************************************************************
-* Function Name  : EXTI_Configuration
-* Description    : Configures the External Interrupts controller.
-* Input          : None
-* Output         : None
-* Return         : None
-*******************************************************************************/
-static void EXTI_Configuration (void)
-{
-    EXTI_InitTypeDef EXTI_InitStructure;
-
-    /* Smartcard OFF Pin */
-    GPIO_EXTILineConfig (SC_PortSource, SC_PinSource_1);
-    GPIO_EXTILineConfig (SC_PortSource, SC_PinSource_2);
-
-    // GPIO_EXTILineConfig(GPIO_PortSourceGPIOA, GPIO_PinSource8);
-    // GPIO_EXTILineConfig(GPIO_PortSourceGPIOB, GPIO_PinSource6);
-
-    /* Clear SC EXTI Line Pending Bit */
-    EXTI_ClearITPendingBit (SC_EXTI);
-
-    EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
-    EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
-    EXTI_InitStructure.EXTI_Line = SC_EXTI;
-    EXTI_InitStructure.EXTI_LineCmd = ENABLE;
-    EXTI_Init (&EXTI_InitStructure);
-}
-
-/*******************************************************************************
 * Function Name  : GPIO_Configuration_Smartcard
 * Description    : configure the poweron port for the smartcard
 * Input          : None.

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -95,11 +95,9 @@ extern uint8_t HID_GetReport_Value[32 + 1];
 uint32_t crc (uint32_t time)
 {
 
-int i, j;
+int i;
 
 uint32_t value = time << 8;
-
-uint32_t crc;
 
     for (i = 0; i < 24; i++)
     {

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -126,7 +126,6 @@ uint8_t i;
 void sendNumberN (uint32_t number, uint8_t len)
 {
 uint8_t result[10] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-uint32_t tmp_number = number;
 
 uint8_t i;
 

--- a/src/keyboard/report_protocol.c
+++ b/src/keyboard/report_protocol.c
@@ -60,8 +60,6 @@ uint32_t received_crc32;
 
 uint32_t calculated_crc32;
 
-uint8_t i;
-
 uint8_t not_authorized = 0;
 
     // uint64_t counter=*((uint64_t *)(report+REPORT_COUNTER_VALUE_OFFSET));
@@ -362,8 +360,6 @@ uint8_t cmd_read_slot_name (uint8_t * report, uint8_t * output)
 {
 
 uint8_t slot_no = report[1];
-
-uint64_t counter;
 
     if (slot_no >= 0x10 && slot_no <= 0x10 + NUMBER_OF_HOTP_SLOTS)
     {   // HOTP slot
@@ -1060,8 +1056,6 @@ u8 MasterKey_au8[AES_KEYSIZE_256_BIT];
 
 uint8_t cmd_getProDebug (uint8_t * report, uint8_t * output)
 {
-u32 ret;
-
 unsigned char data[OUTPUT_CMD_RESULT_LENGTH];
 
 unsigned int data_length = 0;

--- a/src/pwd-safe/FlashStorage.c
+++ b/src/pwd-safe/FlashStorage.c
@@ -946,9 +946,6 @@ u32 i1;
 
 uint8_t page_buffer[FLASH_PAGE_SIZE];
 
-uint8_t* page;
-
-
     // Clear user page
     for (i1 = 0; i1 < 7; i1++)
     {

--- a/src/pwd-safe/HandleAesStorageKey.c
+++ b/src/pwd-safe/HandleAesStorageKey.c
@@ -252,10 +252,6 @@ u32 BuildNewXorPattern_u32 (void)
 {
 u8 XorPattern_au8[AES_KEYSIZE_256_BIT];
 
-time_t now;
-
-u32 i;
-
 #ifdef LOCAL_DEBUG
     // CI_TickLocalPrintf ("BuildNewXorPattern_u32\r\n");
 #endif

--- a/src/pwd-safe/password_safe.c
+++ b/src/pwd-safe/password_safe.c
@@ -133,11 +133,7 @@ typePasswordSafeSlot_st PWS_BufferSlot_st;
 
 u8 PWS_WriteSlot (u8 Slot_u8, typePasswordSafeSlot_st * Slot_st)
 {
-u8* WritePointer_pu8;
-
 u8* AesKeyPointer_pu8;
-
-void* p;
 
     CI_LocalPrintf
         ("PWS_WriteSlot: Slot %d. Name -%s- Loginname -%s- PW -%s-\r\n",
@@ -187,9 +183,6 @@ int i;
     CI_LocalPrintf ("\n\r");
 #endif
 
-    // Get write address
-    WritePointer_pu8 = (u8 *) (PWS_FLASH_START_ADDRESS + (PWS_SLOT_LENGTH * Slot_u8));
-
     // Write to flash
 uint8_t page_buffer[FLASH_PAGE_SIZE];
 
@@ -198,7 +191,6 @@ uint8_t* page = (uint8_t *) PWS_FLASH_START_ADDRESS;
     memcpy (page_buffer, page, FLASH_PAGE_SIZE);
     memcpy (page_buffer + (PWS_SLOT_LENGTH * Slot_u8), Slot_st_encrypted, PWS_SLOT_LENGTH);
 
-    p = (void *) Slot_st_encrypted;
     FLASH_Unlock ();
     FLASH_ErasePage (PWS_FLASH_START_ADDRESS);
     write_data_to_flash (page_buffer, FLASH_PAGE_SIZE, PWS_FLASH_START_ADDRESS);
@@ -224,11 +216,7 @@ uint8_t* page = (uint8_t *) PWS_FLASH_START_ADDRESS;
 
 u8 PWS_EraseSlot (u8 Slot_u8)
 {
-u8* WritePointer_pu8;
-
 u8* AesKeyPointer_pu8;
-
-void* p;
 
 #if (defined __GNUC__) && (defined __AVR32__)
     __attribute__ ((__aligned__ (4)))
@@ -285,9 +273,6 @@ int i;
     CI_LocalPrintf ("\n\r");
 #endif
 
-    // Get write address
-    WritePointer_pu8 = (u8 *) (PWS_FLASH_START_ADDRESS + (PWS_SLOT_LENGTH * Slot_u8));
-
     // Write to flash
 uint8_t page_buffer[FLASH_PAGE_SIZE];
 
@@ -296,7 +281,6 @@ uint8_t* page = (uint8_t *) PWS_FLASH_START_ADDRESS;
     memcpy (page_buffer, page, FLASH_PAGE_SIZE);
     memcpy (page_buffer + (PWS_SLOT_LENGTH * Slot_u8), Slot_st_encrypted, PWS_SLOT_LENGTH);
 
-    p = (void *) Slot_st_encrypted;
     FLASH_Unlock ();
     FLASH_ErasePage (PWS_FLASH_START_ADDRESS);
     write_data_to_flash (page_buffer, FLASH_PAGE_SIZE, PWS_FLASH_START_ADDRESS);

--- a/src/stm/Libraries/STM32_USB-FS-Device_Driver/src/usb_core.c
+++ b/src/stm/Libraries/STM32_USB-FS-Device_Driver/src/usb_core.c
@@ -180,7 +180,7 @@ uint8_t* Standard_GetStatus (uint16_t Length)
     if (Type_Recipient == (STANDARD_REQUEST | DEVICE_RECIPIENT))
     {
         /* Get Device Status */
-uint8_t Feature = pInformation->Current_Feature;
+//uint8_t Feature = pInformation->Current_Feature;
 
         /* Remote Wakeup enabled */
         ClrBit (StatusInfo0, 1);


### PR DESCRIPTION
This includes a missing return, which seems to fix #9

I am still not sure about the correctness of testScAesKey, so don't apply this yet. The switch statement looks very fishy. What exactly is the meaning of nRet and what do the callers of testScAesKey expect as return value?

All other changes should at least not introduce regressions (but also no fixes).
