### PR TITLE
Add debugging functions

### DIFF
--- a/build/gcc/Makefile
+++ b/build/gcc/Makefile
@@ -71,6 +71,7 @@ TARGET = nitrokey-hsm-firmware
 # List C source files here. (C dependencies are automatically generated.)
 # use file-extension c for "c-only"-files
 SRC = 		../../src/main.c                                         \
+			../../src/debug.c                                         \
 			../../src/hw_config.c                                         \
 			../../src/test_code.c                                         \
 			../../src/utils/delays.c	\

--- a/debug.py
+++ b/debug.py
@@ -1,0 +1,31 @@
+import usb.core
+import sys
+import time
+
+# This script waits for a Nitrokey HSM in debug mode to be attached
+# and prints all debug output. Timeouts are ignored. All other 
+# communication errors produce an error message and the script
+# continues by waiting for a device to be attached.
+# Make sure the script is running before the Nitrokey is attached
+# to prevent timeouts in other applications.
+
+while True:
+	# TODO: Other device types
+	dev = usb.core.find(idVendor=0x20a0, idProduct=0x4230)
+	if dev is None:
+    		time.sleep(0.01)
+    		continue
+	dev.set_configuration()
+	print "DEVICE ATTACHED, LOGGING:"
+	while True:
+		try:
+			bytes = dev.read(0x85, 32)
+			sys.stdout.write(bytes.tostring())
+			sys.stdout.flush()
+		except usb.core.USBError as e:
+			if e[0] == 110:
+				continue
+			print "COMMUNICATION ERROR:"
+			print e
+			break
+

--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_desc.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_desc.c
@@ -59,7 +59,7 @@ const uint8_t CCID_ConfigDescriptor[CCID_SIZ_CONFIG_DESC] = {
     0x09,   /* bLength ConfigDescriptor */
     0x02,   /* bDescriptorType */
     CCID_SIZ_CONFIG_DESC,  0x00, /* uint16_t wTotalLength */
-    0x01,   /* bNumInterfaces */
+    0x02,   /* bNumInterfaces */
     0x01,   /* bConfigurationValue */
     0x00,   /* iConfiguration CCID = 6 ???? */
     USB_CONFIG_BUS_POWERED, /* bmAttributes */
@@ -149,7 +149,25 @@ const uint8_t CCID_ConfigDescriptor[CCID_SIZ_CONFIG_DESC] = {
     0x00,   // wMaxPacketSize (MSB)
     0x00,   // bInterval: ignored
 
+    // Interface 1 descriptor (Interface 1 = Debug interface)
+    0x09,   /* bLength */
+    0x04,   /* bDescriptorType */
+    0x01,   /* bInterfaceNumber */
+    0x00,   /* bAlternateSetting */
+    0x01,   /* bNumEndpoints = 1 */
+    0xFF,   /* bInterfaceClass = Vendor specific */
+    0x00,   /* bInterfaceSubClass */
+    0x00,   /* bInterfaceProtocol */
+    0x00,   /* iInterface Index of string descriptor */
 
+    // Endpoint 5 descriptor (Interrupt IN for debug)
+    0x07,   /* bLength */
+    0x05,   // bDescriptorType: Endpoint descriptor type
+    0x85,   // bEndpointAddress: Endpoint 5 IN
+    0x03,   // bmAttributes: Interrupt endpoint
+    0x20,   // wMaxPacketSize(LSB): 32 byte
+    0x00,   // wMaxPacketSize (MSB)
+    0x18,   // bInterval: Polling Interval (24 ms = 0x18)
 };
 
 

--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
@@ -217,6 +217,12 @@ void USB_CCID_Reset (void)
     SetEPRxStatus (ENDP4, EP_RX_DIS);
     SetEPTxStatus (ENDP4, EP_TX_NAK);
 
+    /* Initialize Endpoint 5 */
+    SetEPType (ENDP5, EP_INTERRUPT);
+    SetEPTxAddr (ENDP5, ENDP5_TXADDR);
+    SetEPTxStatus (ENDP5, EP_TX_NAK);
+    SetEPRxStatus (ENDP5, EP_RX_DIS);
+
     /* */
     SetEPRxCount (ENDP0, Device_Property->MaxPacketSize);
     SetEPRxValid (ENDP0);

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,49 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include "usb_lib.h"
+#include "CCIDHID_usb_conf.h"
+#include "CCIDHID_usb_desc.h"
+#include "usb_pwr.h"
+#include "usb_bot.h"
+#include "hw_config.h"
+#include "CCIDHID_usb_prop.h"
+#include "CCIDHID_usb.h"
+#include "debug.h"
+
+__IO uint8_t DebugTransferComplete;
+
+void Debug(uint8_t *buffer, size_t length) {
+#ifdef DBG
+  // Split buffer into transfers of length 32 or less, which are
+  // sent to the host individually.
+  while (length != 0) {
+    // Determine next transfer length (32 bytes or less)
+    size_t messageLength = 32;
+    if (length < messageLength)
+      messageLength = length;
+    // Start transfer
+    DebugTransferComplete = 0;
+    UserToPMABufferCopy(buffer, ENDP5_TXADDR, messageLength);
+    SetEPTxCount(ENDP5, messageLength);
+    SetEPTxStatus(ENDP5, EP_TX_VALID);
+    // Wait for content to arrive at host
+    while (DebugTransferComplete == 0)
+      ;
+    // Move forward in buffer
+    length -= messageLength;
+    buffer += messageLength;
+  }
+#endif
+}
+
+void Debugf(const char *format, ...) {
+#ifdef DBG
+  char buffer[512];
+  va_list args;
+  va_start(args, format);
+  int length = vsnprintf(buffer, 512, format, args);
+  va_end(args);
+  if (length > 0)
+    Debug((uint8_t *)buffer, (size_t)length);
+#endif
+}

--- a/src/inc/CCIDHID_usb_desc.h
+++ b/src/inc/CCIDHID_usb_desc.h
@@ -30,7 +30,7 @@
 /* Exported macro ------------------------------------------------------------ */
 /* Exported define ----------------------------------------------------------- */
 #define CCID_SIZ_DEVICE_DESC              18
-#define CCID_SIZ_CONFIG_DESC              (9 + 9 + 0x36 + 3*0x07)
+#define CCID_SIZ_CONFIG_DESC              (9 + 9 + 0x36 + 3*7 + 9 + 7)
 // #define CCID_SIZ_CONFIG_DESC (1*0x09 + 3*0x09 +0x36 + 4*0x07)
 // #define CCID_SIZ_CONFIG_DESC (3*0x09 +2*0x36 + 6*0x07)
 

--- a/src/inc/debug.h
+++ b/src/inc/debug.h
@@ -1,0 +1,19 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+#include <stddef.h>
+
+// Uncomment the following line to enable debugging.
+// If debugging is enabled, the host must listen to
+// interrupt transfers on endpoint 5.
+// #define DBG
+
+// Sends the buffer contents as a series of interrupt
+// transfers. All transfers are guaranteed to arrive
+// before execution continues.
+void Debug(uint8_t *buffer, size_t length);
+
+// Wrapper for Debug with the same prototype as printf.
+// Sends only up to 512 bytes. The remaining bytes are
+// ignored. See Debug for more details.
+void Debugf(const char *format, ...);
+#endif

--- a/src/inc/usb_conf.h
+++ b/src/inc/usb_conf.h
@@ -27,7 +27,7 @@
 /* EP_NUM */
 /* defines how many endpoints are used by the device */
 /*-------------------------------------------------------------*/
-#define EP_NUM                          (5)
+#define EP_NUM                          (6)
 
 /*-------------------------------------------------------------*/
 /* -------------- Buffer Description Table ----------------- */
@@ -56,6 +56,9 @@
 // #define ENDP3_TXADDR (0x158)
 #define ENDP4_TXADDR        (0x19C)
 
+/* EP5 */
+/* tx buffer base address */
+#define ENDP5_TXADDR        (0x1DC)
 
 /* ISTR events */
 /* IMR_MSK */
@@ -72,7 +75,7 @@
 // #define EP2_IN_Callback NOP_Process
 #define  EP3_IN_Callback   NOP_Process
 // #define EP4_IN_Callback NOP_Process
-#define  EP5_IN_Callback   NOP_Process
+// #define  EP5_IN_Callback   NOP_Process
 #define  EP6_IN_Callback   NOP_Process
 #define  EP7_IN_Callback   NOP_Process
 

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@
 #include "string.h"
 #include "CcidLocalAccess.h"
 #include "HandleAesStorageKey.h"
+#include "debug.h"
 
 
 
@@ -127,6 +128,7 @@ int main (void)
     StartupCheck_u8 ();
 
     /* Endless loop after USB startup */
+    Debugf("Entering loop after USB startup\n");
     while (1)
     {
         if (device_status == STATUS_RECEIVED_REPORT)

--- a/src/usb/usb_endp.c
+++ b/src/usb/usb_endp.c
@@ -32,6 +32,7 @@
 /* Private macro ------------------------------------------------------------- */
 /* Private variables --------------------------------------------------------- */
 extern __IO uint8_t PrevXferComplete;
+extern __IO uint8_t DebugTransferComplete;
 
 /* Private function prototypes ----------------------------------------------- */
 /* Private functions --------------------------------------------------------- */
@@ -99,3 +100,9 @@ void EP4_IN_Callback (void)
     PrevXferComplete = 1;
     // SwitchSmartcardLED(DISABLE);
 }
+
+void EP5_IN_Callback (void)
+{
+    DebugTransferComplete = 1;
+}
+


### PR DESCRIPTION
Adds two simple functions for debugging.

Debugf works exactly like printf.
Debug takes an array of bytes and a length.
Example code on device:
```C
Debugf("Hello world %d", 123)
```
Output on host:
```
$python debug.py
Hello world 123
```

Debugging is disabled by default. Both functions do nothing unless debugging in is enabled by uncommenting line 8 in debug.h (this should be done via make target at some point)

To try it uncomment line 8 in src/inc/debug.h and run "python debug.py" in the repository root. Then plug in the Nitrokey HSM. You should see this as soon as the device is done with the basic setup:
```
Entering loop after USB startup
```

This code should have no side effects and be compatible with the master branch as well. More extensive documentation in debug.py and debug.h.

Don't use floating point math (that means don't print them either).