### PR TITLE
Handle bigger OTP secrets up to 40 bytes, 320 bits

### DIFF
--- a/src/ccid/CcidLocalAccess.c
+++ b/src/ccid/CcidLocalAccess.c
@@ -975,23 +975,24 @@ unsigned short cRet;
     if (APDU_ANSWER_COMMAND_CORRECT != cRet)
         return 0;
 
+  const size_t SLOT_SIZE = sizeof(OTP_slot);
     // Erase OTP slots
 uint8_t slot_no;
 
-uint8_t slot_tmp[64];
+uint8_t slot_tmp[SLOT_SIZE];
 
-    memset (slot_tmp, 0xFF, 64);
+    memset (slot_tmp, 0xFF, SLOT_SIZE);
 
-    for (slot_no = 0; slot_no < NUMBER_OF_HOTP_SLOTS; slot_no++)    // HOTP
+  for (slot_no = 0; slot_no < NUMBER_OF_HOTP_SLOTS; slot_no++)    // HOTP
         // slots
     {
-        write_to_slot (slot_tmp, hotp_slot_offsets[slot_no], 64);
+        write_to_slot (slot_tmp, get_HOTP_slot_offset(slot_no), SLOT_SIZE);
         erase_counter (slot_no);
     }
     for (slot_no = 0; slot_no < NUMBER_OF_TOTP_SLOTS; slot_no++)    // TOTP
         // slots
     {
-        write_to_slot (slot_tmp, totp_slot_offsets[slot_no], 64);
+        write_to_slot (slot_tmp, get_TOTP_slot_offset(slot_no), SLOT_SIZE);
     }
 
     // Default flash memory

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -495,16 +495,17 @@ uint8_t* page = (uint8_t *) current_slot_address;
 
     // check if the secret from the tool is empty and if it is use the old
     // secret
-    uint8_t* secret = (uint8_t *) (data + SECRET_OFFSET);
+    uint8_t* secret = new_slot_data->secret;
     uint8_t empty = TRUE;
-    for (int i = 0; i<20; i++) {
+    for (int i = 0; i<SECRET_LENGTH; i++) {
       if (secret[i] != 0x00) {
         empty = FALSE;
         break;
       }
     }
     if (empty == TRUE) {
-        memcpy (data + SECRET_OFFSET, page_buffer + offset + SECRET_OFFSET, 20);
+      OTP_slot * stored_otp_slot = (OTP_slot *) (page_buffer + offset);
+      memcpy (new_slot_data->secret, stored_otp_slot->secret, SECRET_LENGTH);
     }
 
     // make changes to page

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -1,3 +1,4 @@
+const int SECRET_LENGTH = 40;
 /*
  * Author: Copyright (C) Andrzej Surowiec 2012
  *
@@ -28,46 +29,33 @@
 #include "string.h"
 #include "memory_ops.h"
 
-__I uint32_t hotp_slots[NUMBER_OF_HOTP_SLOTS] = { SLOTS_PAGE1_ADDRESS + HOTP_SLOT1_OFFSET,
-    SLOTS_PAGE1_ADDRESS + HOTP_SLOT2_OFFSET,
-    SLOTS_PAGE1_ADDRESS + HOTP_SLOT3_OFFSET
-};
-
 __I uint32_t hotp_slot_counters[NUMBER_OF_HOTP_SLOTS] = { SLOT1_COUNTER_ADDRESS,
     SLOT2_COUNTER_ADDRESS,
     SLOT3_COUNTER_ADDRESS
 };
 
-__I uint32_t hotp_slot_offsets[NUMBER_OF_HOTP_SLOTS] = { HOTP_SLOT1_OFFSET,
-    HOTP_SLOT2_OFFSET,
-    HOTP_SLOT3_OFFSET
-};
-
-__I uint32_t totp_slots[NUMBER_OF_TOTP_SLOTS] = { SLOTS_PAGE1_ADDRESS + TOTP_SLOT1_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT2_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT3_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT4_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT5_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT6_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT7_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT8_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT9_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT10_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT11_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT12_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT13_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT14_OFFSET,
-    SLOTS_PAGE1_ADDRESS + TOTP_SLOT15_OFFSET
-};
-
-__I uint32_t totp_slot_offsets[NUMBER_OF_TOTP_SLOTS] = { TOTP_SLOT1_OFFSET, TOTP_SLOT2_OFFSET, TOTP_SLOT3_OFFSET,
-    TOTP_SLOT4_OFFSET, TOTP_SLOT5_OFFSET, TOTP_SLOT6_OFFSET,
-    TOTP_SLOT7_OFFSET, TOTP_SLOT8_OFFSET, TOTP_SLOT9_OFFSET,
-    TOTP_SLOT10_OFFSET, TOTP_SLOT11_OFFSET, TOTP_SLOT12_OFFSET,
-    TOTP_SLOT13_OFFSET, TOTP_SLOT14_OFFSET, TOTP_SLOT15_OFFSET
-};
-
 uint8_t page_buffer[SLOT_PAGE_SIZE];
+
+
+uint32_t get_HOTP_slot_offset(int slot_count){
+    return SLOTS_PAGE1_ADDRESS + get_slot_offset(slot_count);
+}
+
+uint32_t get_TOTP_slot_offset(int slot_count){
+    return SLOTS_PAGE1_ADDRESS + get_slot_offset(slot_count + 3);
+}
+
+uint32_t get_slot_offset(int slot_count){
+    const int global_config_offset = 64;
+    size_t slot_offset = sizeof(OTP_slot) * slot_count + global_config_offset;
+    const int first_page_limit = SLOT_PAGE_SIZE - sizeof(OTP_slot); //TODO check these limits
+    const int second_page_start = 1024+8;
+    if (slot_offset > first_page_limit){
+        slot_offset -= first_page_limit;
+        slot_offset += second_page_start;
+    }
+    return slot_offset;
+}
 
 uint64_t endian_swap (uint64_t x)
 {
@@ -428,12 +416,13 @@ uint8_t config = 0;
     if (config & (1 << SLOT_CONFIG_DIGITS))
         len = 8;
 
-    result = *((uint8_t *) hotp_slots[slot]);
+    OTP_slot * hotp_slot = ((OTP_slot *) get_HOTP_slot_offset(slot));
+    result = hotp_slot->type;
     if (result == 0xFF) // unprogrammed slot
         return 0;
 
     counter = get_counter_value (hotp_slot_counters[slot]);
-    result = get_hotp_value (counter, (uint8_t *) (hotp_slots[slot] + SECRET_OFFSET), SECRET_LENGTH, len);
+    result = get_hotp_value (counter, hotp_slot->secret, SECRET_LENGTH, len);
     err = increment_counter_page (hotp_slot_counters[slot]);
     if (err != FLASH_COMPLETE)
         return 0;
@@ -472,25 +461,27 @@ void erase_counter (uint8_t slot)
 }
 
 
-void write_to_slot (uint8_t * data, uint16_t offset, uint16_t len)
+void write_to_slot(OTP_slot *new_slot_data, uint32_t offset, uint16_t len)
 {
+   uint8_t page_buffer[SLOT_PAGE_SIZE];
 
 FLASH_Status err = FLASH_COMPLETE;
 
     // choose the proper slot page
-uint32_t current_slot_address;
+  uint32_t current_slot_address;
 
-    if (offset < 1024)
-        current_slot_address = SLOTS_PAGE1_ADDRESS;
-    else
-    {
-        offset -= 1024;
+    if (offset > SLOTS_PAGE2_ADDRESS){
         current_slot_address = SLOTS_PAGE2_ADDRESS;
+        offset-= SLOTS_PAGE2_ADDRESS;
+    } else {
+        current_slot_address = SLOTS_PAGE1_ADDRESS;
+        if (offset>SLOTS_PAGE1_ADDRESS){
+            offset -= SLOTS_PAGE1_ADDRESS;
+        }
     }
 
     // copy entire page to ram
-uint8_t* page = (uint8_t *) current_slot_address;
-
+    uint8_t* page = (uint8_t *) current_slot_address;
     memcpy (page_buffer, page, SLOT_PAGE_SIZE);
 
     // check if the secret from the tool is empty and if it is use the old
@@ -509,7 +500,7 @@ uint8_t* page = (uint8_t *) current_slot_address;
     }
 
     // make changes to page
-    memcpy (page_buffer + offset, data, len);
+    memcpy (page_buffer + offset, new_slot_data, len);
 
     // write page to backup location
     backup_data (page_buffer, SLOT_PAGE_SIZE, current_slot_address);
@@ -576,7 +567,8 @@ uint8_t result = 0;
         return 0;
     else
     {
-        result = ((uint8_t *) hotp_slots[slot_number])[CONFIG_OFFSET];
+      OTP_slot* otp_slot = (OTP_slot *) get_HOTP_slot_offset(slot_number);
+      result = otp_slot->config;
     }
 
     return result;
@@ -590,7 +582,8 @@ uint8_t result = 0;
         return 0;
     else
     {
-        result = ((uint8_t *) totp_slots[slot_number])[CONFIG_OFFSET];
+      OTP_slot* otp_slot = (OTP_slot *) get_TOTP_slot_offset(slot_number);
+      result = otp_slot->config;
     }
 
     return result;
@@ -615,11 +608,13 @@ uint8_t len = 6;
 
     // memset(time,0,18);
 
-    interval = getu16 (totp_slots[slot] + INTERVAL_OFFSET);
+    OTP_slot* otp_slot = (OTP_slot *) get_TOTP_slot_offset(slot);
+
+    interval = otp_slot->interval_or_counter;
 
     time = current_time / interval;
 
-    result = *((uint8_t *) totp_slots[slot]);
+    result = otp_slot->type;
     if (result == 0xFF) // unprogrammed slot
         return 0;
 
@@ -630,7 +625,7 @@ uint8_t len = 6;
 
     // result= get_hotp_value(challenge,(uint8_t
     // *)(totp_slots[slot]+SECRET_OFFSET),20,len);
-    result = get_hotp_value (time, (uint8_t *) (totp_slots[slot] + SECRET_OFFSET), SECRET_LENGTH, len);
+    result = get_hotp_value (time, otp_slot->secret, SECRET_LENGTH, len);
 
     return result;
 

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -1,4 +1,3 @@
-const int SECRET_LENGTH = 40;
 /*
  * Author: Copyright (C) Andrzej Surowiec 2012
  *
@@ -28,6 +27,8 @@ const int SECRET_LENGTH = 40;
 #include "hotp.h"
 #include "string.h"
 #include "memory_ops.h"
+
+const int SECRET_LENGTH = SECRET_LENGTH_DEFINE;
 
 __I uint32_t hotp_slot_counters[NUMBER_OF_HOTP_SLOTS] = { SLOT1_COUNTER_ADDRESS,
     SLOT2_COUNTER_ADDRESS,

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -44,11 +44,31 @@ uint32_t get_HOTP_slot_offset(int slot_count){
 uint32_t get_TOTP_slot_offset(int slot_count){
     return SLOTS_PAGE1_ADDRESS + get_slot_offset(slot_count + 3);
 }
-
+/*
+78 per slot
+0 64-141
+1 142-219
+2 220-297
+3 298-375
+4 376-453
+5 454-531
+6 532-609
+7 610-687
+8 688-765
+9 766-843
+10 844-921
+11 922-999
+12 1110-1187
+13 1188-1265
+14 1266-1343
+15 1344-1421
+16 1422-1499
+17 1500-1577
+ */
 uint32_t get_slot_offset(int slot_count){
     const int global_config_offset = 64;
     size_t slot_offset = sizeof(OTP_slot) * slot_count + global_config_offset;
-    const int first_page_limit = SLOT_PAGE_SIZE - sizeof(OTP_slot); //TODO check these limits
+    const int first_page_limit = SLOT_PAGE_SIZE - sizeof(OTP_slot);
     const int second_page_start = 1024+8;
     if (slot_offset > first_page_limit){
         slot_offset -= first_page_limit;

--- a/src/hotp/hotp.c
+++ b/src/hotp/hotp.c
@@ -433,7 +433,7 @@ uint8_t config = 0;
         return 0;
 
     counter = get_counter_value (hotp_slot_counters[slot]);
-    result = get_hotp_value (counter, (uint8_t *) (hotp_slots[slot] + SECRET_OFFSET), 20, len);
+    result = get_hotp_value (counter, (uint8_t *) (hotp_slots[slot] + SECRET_OFFSET), SECRET_LENGTH, len);
     err = increment_counter_page (hotp_slot_counters[slot]);
     if (err != FLASH_COMPLETE)
         return 0;
@@ -629,7 +629,7 @@ uint8_t len = 6;
 
     // result= get_hotp_value(challenge,(uint8_t
     // *)(totp_slots[slot]+SECRET_OFFSET),20,len);
-    result = get_hotp_value (time, (uint8_t *) (totp_slots[slot] + SECRET_OFFSET), 20, len);
+    result = get_hotp_value (time, (uint8_t *) (totp_slots[slot] + SECRET_OFFSET), SECRET_LENGTH, len);
 
     return result;
 

--- a/src/inc/hotp.h
+++ b/src/inc/hotp.h
@@ -106,6 +106,7 @@ extern __I uint32_t totp_slot_offsets[NUMBER_OF_TOTP_SLOTS];
 
 extern uint8_t page_buffer[SLOT_PAGE_SIZE];
 
+static const int SECRET_LENGTH = 20;
 uint64_t current_time;
 
 uint64_t endian_swap (uint64_t x);

--- a/src/inc/hotp.h
+++ b/src/inc/hotp.h
@@ -75,13 +75,13 @@
 
 typedef struct {
     uint8_t type;
+    uint8_t slot_number;
     uint8_t name[15];
     uint8_t secret[40];
     uint8_t config;
     uint8_t token_id[13];
     uint64_t interval_or_counter;
 } __packed OTP_slot;
-//} OTP_slot;
 
 #define TIME_OFFSET 4
 

--- a/src/inc/hotp.h
+++ b/src/inc/hotp.h
@@ -17,6 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with Nitrokey. If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
+
+#include <stdint.h>
 
 #define NUMBER_OF_HOTP_SLOTS 3
 #define NUMBER_OF_TOTP_SLOTS 15
@@ -65,48 +68,26 @@
 
 #define GLOBAL_CONFIG_OFFSET 0
 
-#define HOTP_SLOT1_OFFSET 64
-#define HOTP_SLOT2_OFFSET 128
-#define HOTP_SLOT3_OFFSET 192
 
-#define TOTP_SLOT1_OFFSET 256
-#define TOTP_SLOT2_OFFSET 320
-#define TOTP_SLOT3_OFFSET 384
-#define TOTP_SLOT4_OFFSET 448
-#define TOTP_SLOT5_OFFSET 512
-#define TOTP_SLOT6_OFFSET 576
-#define TOTP_SLOT7_OFFSET 640
-#define TOTP_SLOT8_OFFSET 704
-#define TOTP_SLOT9_OFFSET 768
-#define TOTP_SLOT10_OFFSET 832
-#define TOTP_SLOT11_OFFSET 896
-#define TOTP_SLOT12_OFFSET 1088
-#define TOTP_SLOT13_OFFSET 1152
-#define TOTP_SLOT14_OFFSET 1216
-#define TOTP_SLOT15_OFFSET 1280
+#define __packed __attribute__((__packed__))
 
-#define SLOT_TYPE_OFFSET 0
-#define SLOT_NAME_OFFSET 1
-#define SECRET_OFFSET 16
-#define CONFIG_OFFSET 36
-#define TOKEN_ID_OFFSET 37
-#define INTERVAL_OFFSET 50
+//0 - HOTP, 1 - TOTP, FF - not programmed
+
+typedef struct {
+    uint8_t type;
+    uint8_t name[15];
+    uint8_t secret[40];
+    uint8_t config;
+    uint8_t token_id[13];
+    uint64_t interval_or_counter;
+} __packed OTP_slot;
+//} OTP_slot;
 
 #define TIME_OFFSET 4
 
-extern __I uint32_t hotp_slots[NUMBER_OF_HOTP_SLOTS];
-
-extern __I uint32_t totp_slots[NUMBER_OF_TOTP_SLOTS];
-
 extern __I uint32_t hotp_slot_counters[NUMBER_OF_HOTP_SLOTS];
 
-extern __I uint32_t hotp_slot_offsets[NUMBER_OF_HOTP_SLOTS];
 
-extern __I uint32_t totp_slot_offsets[NUMBER_OF_TOTP_SLOTS];
-
-extern uint8_t page_buffer[SLOT_PAGE_SIZE];
-
-static const int SECRET_LENGTH = 20;
 uint64_t current_time;
 
 uint64_t endian_swap (uint64_t x);
@@ -130,7 +111,7 @@ uint32_t get_code_from_hotp_slot (uint8_t slot);
 
 uint8_t increment_counter_page (uint32_t addr);
 
-void write_to_slot (uint8_t * data, uint16_t offset, uint16_t len);
+void write_to_slot(OTP_slot *new_slot_data, uint32_t offset, uint16_t len);
 
 void backup_data (uint8_t * data, uint16_t len, uint32_t addr);
 
@@ -141,3 +122,7 @@ uint8_t get_hotp_slot_config (uint8_t slot_number);
 uint8_t get_totp_slot_config (uint8_t slot_number);
 
 uint32_t get_code_from_totp_slot (uint8_t slot, uint64_t challenge);
+
+extern uint32_t get_HOTP_slot_offset(int slot_count);
+extern uint32_t get_TOTP_slot_offset(int slot_count);
+extern uint32_t get_slot_offset(int slot_count);

--- a/src/inc/hotp.h
+++ b/src/inc/hotp.h
@@ -73,7 +73,7 @@
 #define SECRET_LENGTH_DEFINE 40
 
 typedef struct {
-    uint8_t type; //0 - HOTP, 1 - TOTP, FF - not programmed
+    uint8_t type; //'H' - HOTP, 'T' - TOTP, FF - not programmed
     uint8_t slot_number;
     uint8_t name[15];
     uint8_t secret[SECRET_LENGTH_DEFINE];

--- a/src/inc/hotp.h
+++ b/src/inc/hotp.h
@@ -70,14 +70,13 @@
 
 
 #define __packed __attribute__((__packed__))
-
-//0 - HOTP, 1 - TOTP, FF - not programmed
+#define SECRET_LENGTH_DEFINE 40
 
 typedef struct {
-    uint8_t type;
+    uint8_t type; //0 - HOTP, 1 - TOTP, FF - not programmed
     uint8_t slot_number;
     uint8_t name[15];
-    uint8_t secret[40];
+    uint8_t secret[SECRET_LENGTH_DEFINE];
     uint8_t config;
     uint8_t token_id[13];
     uint64_t interval_or_counter;

--- a/src/inc/report_protocol.h
+++ b/src/inc/report_protocol.h
@@ -269,6 +269,5 @@ typedef struct {
     uint8_t temporary_admin_password[25];
     uint8_t type; //0-secret, 1-name
     uint8_t id; //multiple reports
-    uint8_t length; //data length
     uint8_t data[30]; //data, does not need null termination
 } __packed cmd_send_OTP_data;

--- a/src/inc/report_protocol.h
+++ b/src/inc/report_protocol.h
@@ -18,6 +18,9 @@
  * along with Nitrokey. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+#include "hotp.h"
+
 #define FIRMWARE_VERSION (0x08)
 
 #define CMD_GET_STATUS                      0x00
@@ -42,6 +45,8 @@
 #define CMD_CHANGE_USER_PIN                 0x14
 #define CMD_CHANGE_ADMIN_PIN                0x15
 #define CMD_WRITE_TO_SLOT_2                 0x16
+#define CMD_SEND_OTP_DATA                       0x17
+
 
 #define CMD_GET_PW_SAFE_SLOT_STATUS       0x60
 #define CMD_GET_PW_SAFE_SLOT_NAME         0x61
@@ -159,14 +164,13 @@
  */
 
 
-
 __IO extern uint8_t device_status;
 
 uint8_t parse_report (uint8_t * report, uint8_t * output);
 
 uint8_t cmd_get_status (uint8_t * report, uint8_t * output);
 
-uint8_t cmd_write_to_slot (uint8_t * report, uint8_t * output);
+uint8_t cmd_write_to_slot (OTP_slot *new_slot_data, uint8_t * output);
 
 uint8_t cmd_read_slot_name (uint8_t * report, uint8_t * output);
 
@@ -235,7 +239,11 @@ uint8_t cmd_getProDebug (uint8_t * report, uint8_t * output);
 typedef struct {
     uint8_t _command_type;
     uint8_t temporary_admin_password[25];
-    uint8_t slot_secret[20];
+    uint8_t slot_number;
+    union {
+        uint64_t slot_counter_or_interval;
+        uint8_t slot_counter_s[8];
+    } __packed;
     union {
         uint8_t _slot_config;
         struct {
@@ -253,50 +261,15 @@ typedef struct {
             uint8_t keyboard_layout; //disabled feature in nitroapp as of 20160805
         } slot_token_fields;
     };
-} __packed write_to_slot_1_payload;
-
-typedef struct {
-    uint8_t _command_type;
-    uint8_t temporary_admin_password[25];
-    uint8_t slot_number;
-    uint8_t slot_name[15];
-    union {
-        uint64_t slot_counter;
-        uint8_t slot_counter_s[8];
-        struct {
-            uint16_t slot_interval;
-            uint16_t __padding[3];
-        };
-    } __packed;
-} __packed write_to_slot_2_payload;
-
-typedef struct {
-    uint8_t _command_type;
-    uint8_t slot_number;
-    uint8_t slot_name[15];
-    uint8_t slot_secret[20];
-    union {
-        uint8_t _slot_config;
-        struct {
-            bool use_8_digits   : 1;
-            bool use_enter      : 1;
-            bool use_tokenID    : 1;
-        };
-    };
-    union {
-        uint8_t slot_token_id[13]; /** OATH Token Identifier */
-        struct { /** @see https://openauthentication.org/token-specs/ */
-            uint8_t omp[2];
-            uint8_t tt[2];
-            uint8_t mui[8];
-            uint8_t keyboard_layout; //disabled feature in nitroapp as of 20160805
-        } slot_token_fields;
-    };
-    union {
-        uint64_t slot_counter;
-        uint8_t slot_counter_s[8];
-    } __packed;
-} __packed OTP_slot_content;
+} __packed write_to_slot_payload;
 
 static const int CMD_WRITE_CONFIG_PASSWORD_OFFSET = 6;
 static const int CMD_ERASE_SLOT_PASSWORD_OFFSET = 2;
+
+typedef struct {
+    uint8_t temporary_admin_password[25];
+    uint8_t type; //0-secret, 1-name
+    uint8_t id; //multiple reports
+    uint8_t length; //data length
+    uint8_t data[30]; //data, does not need null termination
+} __packed cmd_send_OTP_data;

--- a/src/inc/report_protocol.h
+++ b/src/inc/report_protocol.h
@@ -44,7 +44,6 @@
 #define CMD_FACTORY_RESET                   0x13
 #define CMD_CHANGE_USER_PIN                 0x14
 #define CMD_CHANGE_ADMIN_PIN                0x15
-#define CMD_WRITE_TO_SLOT_2                 0x16
 #define CMD_SEND_OTP_DATA                       0x17
 
 

--- a/src/keyboard/report_protocol.c
+++ b/src/keyboard/report_protocol.c
@@ -318,10 +318,12 @@ uint8_t cmd_write_to_slot(OTP_slot *new_slot_data, uint8_t *output) {
     slot_no = slot_no & 0x0F;
     uint64_t counter = new_slot_data->interval_or_counter;
     set_counter_value(hotp_slot_counters[slot_no], counter);
+    new_slot_data->type = 'H';
     write_to_slot(new_slot_data, get_HOTP_slot_offset(slot_no), BUFFER_SIZE);
 
   } else if (is_TOTP_slot_number(slot_no)) {
     slot_no = slot_no & 0x0F;
+    new_slot_data->type = 'T';
     write_to_slot(new_slot_data, get_TOTP_slot_offset(slot_no), BUFFER_SIZE);
 
   } else {

--- a/src/keyboard/report_protocol.c
+++ b/src/keyboard/report_protocol.c
@@ -96,9 +96,15 @@ uint8_t parse_report(uint8_t * const report, uint8_t * const output) {
           if (otp_data->type == 'N') {
             size_t bytes_count = s_min(sizeof(otp_data->data), sizeof(local_slot_content.name));
             memcpy(local_slot_content.name, otp_data->data, bytes_count);
+            memcpy(&output[OUTPUT_CMD_RESULT_OFFSET], local_slot_content.name, sizeof(local_slot_content.name));
           } else if (otp_data->type == 'S') {
-            size_t bytes_count = s_min(sizeof(otp_data->data), sizeof(local_slot_content.secret));
-            memcpy(local_slot_content.secret, otp_data->data, bytes_count);
+            size_t offset = otp_data->id * sizeof(otp_data->data);
+            if (offset > sizeof(local_slot_content.secret) ){
+              offset = 0;
+            }
+            size_t bytes_count = s_min(sizeof(otp_data->data), sizeof(local_slot_content.secret)-offset);
+            memcpy(local_slot_content.secret+offset, otp_data->data, bytes_count);
+            memcpy(&output[OUTPUT_CMD_RESULT_OFFSET], local_slot_content.secret, sizeof(local_slot_content.secret));
           }
         } else
           not_authorized = 1;

--- a/src/keyboard/report_protocol.c
+++ b/src/keyboard/report_protocol.c
@@ -872,9 +872,8 @@ uint8_t cmd_newAesKey(uint8_t *report, uint8_t *output) {
   memcpy(admin_password, report + 1, 25);
 
   ret = BuildPasswordSafeKey_u32();
-  if (TRUE == ret)
-    output[OUTPUT_CMD_STATUS_OFFSET] = CMD_STATUS_OK;
-  else {
+  if (TRUE != ret)
+  {
     output[OUTPUT_CMD_STATUS_OFFSET] = CMD_STATUS_AES_CREATE_KEY_FAILED;
     return 0;
   }

--- a/src/main.c
+++ b/src/main.c
@@ -156,7 +156,7 @@ int main(void) {
 }
 
 void sendHOTPCodeForSlot(uint8_t slot_number) {
-  if (slot_number <= 1) {
+  if (slot_number <= 2) {
         OTP_slot *const otp_slot = (OTP_slot *) get_HOTP_slot_offset(slot_number);
         bool programmed = otp_slot->type != 0xFF;
 


### PR DESCRIPTION
This will support AWS-length secrets - 40 bytes
Fixes #22 

Tested using libnitrokey tests under Ubuntu 16.10
[test_report_08.txt](https://github.com/Nitrokey/nitrokey-pro-firmware/files/601454/test_report_08.txt)

Summary:
- added new command for sending OTP data
- removed tables with fixed OTP slots offsets (replaced with function)
- casting slots storage and command packets to structs for easier data manipulation
- allowing for setting any maximum OTP secret size (with a cost of lower count of OTP slots over some size)
- handling 3rd HOTP slot for requesting code by double-pressing special key (+code cleanup)
- removed unused code and comments 