### PR TITLE
Change Success/Error blink intervals

### DIFF
--- a/src/keyboard/report_protocol.c
+++ b/src/keyboard/report_protocol.c
@@ -436,9 +436,9 @@ void wink_correct(bool correct){
   ClearAllBlinking();
 
   if (correct){
-    VerifyBlinkCorrect(10);
+    VerifyBlinkCorrect(20);
   } else {
-    VerifyBlinkError(10);
+    VerifyBlinkError(1000);
   }
 }
 


### PR DESCRIPTION
In practice with the HOTP checks, we would like the success interval to
be longer as a user will first be looking at their screen and may miss
the success blinking on the device. Doubling the interval should be
enough.

In the case of an error, however, we should treat it differently and
blink MUCH longer to make sure the user notices the blinking red LED.
Blinking red indefinitely would be ideal but instead I just increased
the interval to a much larger amount.