### PR TITLE
Fix USB buffer description table corruption

### DIFF
--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
@@ -210,7 +210,7 @@ void USB_CCID_Reset (void)
 
     /* Initialize Endpoint 4 */
     SetEPType (ENDP4, EP_INTERRUPT);
-    SetEPTxAddr (ENDP4, ENDP4_TXADDR);
+    SetEPTxAddr (ENDP4, CCID_ENDP4_TXADDR);
     // SetEPTxCount(ENDP4, 8);
     SetEPRxStatus (ENDP4, EP_RX_DIS);
     SetEPTxStatus (ENDP4, EP_TX_NAK);

--- a/src/inc/CCIDHID_usb_conf.h
+++ b/src/inc/CCIDHID_usb_conf.h
@@ -34,27 +34,30 @@
 /*-------------------------------------------------------------*/
 /* buffer table base address */
 
-#define BTABLE_ADDRESS      (0x00)
+#define BTABLE_ADDRESS           (0x00)
 
-/* EP0 */
-/* rx/tx buffer base address */
-#define CCID_ENDP0_RXADDR        (0x18)
-#define CCID_ENDP0_TXADDR        (0x58)
+// Entries in the Buffer Description Table describe each endpoint buffer location and size:
 
-/* EP1 */
-/* tx buffer base address */
-#define CCID_ENDP1_TXADDR        (0x98)
+// BTABLE_ADDRESS + EPn * 8 + 0: USB_ADDRn_TX  (TX buffer address inside the PMA)
+// BTABLE_ADDRESS + EPn * 8 + 2: USB_COUNTn_TX (bytes present in the TX buffer)
+// BTABLE_ADDRESS + EPn * 8 + 4: USB_ADDRn_RX  (RX buffer address inside the PMA)
+// BTABLE_ADDRESS + EPn * 8 + 6: USB_COUNTn_RX (bytes available/present for the RX buffer)
 
-/* EP2 */
-/* Rx buffer base address */
-#define CCID_ENDP2_RXADDR        (0xD8)
-/* Tx buffer base address */
-#define CCID_ENDP2_TXADDR        (0x118)
+// EP0, size = 64
+#define CCID_ENDP0_RXADDR        (0x40) // BTABLE_ADDRESS + BTABLE max size (64)
+#define CCID_ENDP0_TXADDR        (0x80)
 
-/* EP3 */
-/* tx buffer base address */
-// #define ENDP3_TXADDR (0x158)
-#define ENDP4_TXADDR        (0x19C)
+// EP1, size = 64 (needs to be checked, found nothing using over 4 bytes in code)
+#define CCID_ENDP1_TXADDR        (0xC0)
+
+// EP2, size = 64
+#define CCID_ENDP2_RXADDR        (0x100)
+#define CCID_ENDP2_TXADDR        (0x140)
+
+// EP4, size = 8
+#define CCID_ENDP4_TXADDR        (0x180)
+
+// PMA size is 512 bytes, last buffer address + size must be < 0x200
 
 /* ISTR events */
 /* IMR_MSK */

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -23,7 +23,7 @@
 #include "usb_lib.h"
 #include "hw_config.h"
 #include "usb_pwr.h"
-#include "CCID_usb.h"
+#include "CCIDHID_usb_conf.h"
 #include "keyboard.h"
 #include "AccessInterface.h"
 #include "hotp.h"
@@ -82,7 +82,7 @@ void sendKeys (uint8_t * buffer)
 
         PrevXferComplete = 0;
         /* Use the memory interface function to write to the selected endpoint */
-        UserToPMABufferCopy (buffer, ENDP4_TXADDR, 8);
+        UserToPMABufferCopy (buffer, CCID_ENDP4_TXADDR, 8);
 
         /* Update the data length in the control register */
         SetEPTxCount (ENDP4, 8);


### PR DESCRIPTION
CCID_ENDP0_RXADDR was set to 0x18, so incoming buffers were written from
0x18 to 0x57 in the packet memory area (PMA).

This area contained the USB buffer description table (BTABLE) entry for
endpoint 4 (0x20 to 0x5F), defining its buffer address to 0x19C.

Data sent to the host with endpoint 4 was not the buffer located at the
defined address (0x19C) but some other data from the PMA, depending on
how the BTABLE was corrupted.

This prevented the functions defined in src/keyboard to work properly. It can be reproduced in the main loop like so:

```c
int main(void) {
    // …
    int i = 0;
    while (1) {
        if ((i++ % 100000) == 0) {
            sendKeys((uint8_t *) "01234567");
        }
    }
    // …
}
```

When looking at usb traffic with Wireshark, the received data on endpoint 4 receives some data other than 01234567.