### PR TITLE
Moving ambiguous terms out of license headers.

### DIFF
--- a/build/gcc/STM32_128K_20K_FLASH.ld
+++ b/build/gcc/STM32_128K_20K_FLASH.ld
@@ -1,10 +1,10 @@
-/*
-Linker script for STM32F10x
-Copyright RAISONANCE 2007 (modified by Lanchon 1-Feb-2008)
-You can use, copy and distribute this file freely, but without any waranty.
-Configure memory sizes, end of stack and boot mode for your project here.
-*/
-
+/* 
+ * Copyright RAISONANCE 2007 (modified by Lanchon 1-Feb-2008)
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Linker script for STM32F10x
+ * Configure memory sizes, end of stack and boot mode for your project here.
+ */
 
 /* include the common STM32F10x sub-script */
 INCLUDE "STM32_COMMON.ld"

--- a/build/gcc/STM32_COMMON.ld
+++ b/build/gcc/STM32_COMMON.ld
@@ -1,14 +1,11 @@
-/*
-Common part of the linker scripts for STR32 devices
-Copyright RAISONANCE 2007
-You can use, modify and distribute thisfile freely, but without any waranty.
-*/
+/* Copyright RAISONANCE 2007 */
 
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* Common part of the linker scripts for STR32 devices */
 
 /* default stack sizes. 
-
-These are used by the startup in order to allocate stacks for the different modes.
-*/
+ * These are used by the startup in order to allocate stacks for the different modes.
+ */
 
 __Stack_Size = 1024 ;
 
@@ -19,16 +16,10 @@ __Stack_Init = _estack  - __Stack_Size ;
 /*"PROVIDE" allows to easily override these values from an object file or the commmand line.*/
 PROVIDE ( _Stack_Init = __Stack_Init ) ;
 
-/*
-There will be a link error if there is not this amount of RAM free at the end.
-*/
+/* There will be a link error if there is not this amount of RAM free at the end. */
 _Minimum_Stack_Size = 0x100 ;
 
-
-
-/*
-this sends all unreferenced IRQHandlers to reset
-*/
+/* This sends all unreferenced IRQHandlers to reset */
 
 
 PROVIDE (   Undefined_Handler = 0 ) ;

--- a/build/gcc/STM32_SEC_FLASH.ld
+++ b/build/gcc/STM32_SEC_FLASH.ld
@@ -1,10 +1,10 @@
-/*
-Common part of the linker scripts for STR71x devices in FLASH mode
-(that is, the FLASH is seen at 0)
-Copyright RAISONANCE 2005
-You can use, modify and distribute thisfile freely, but without any waranty.
-*/
+/* Copyright RAISONANCE 2005 */
 
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* Common part of the linker scripts for STR71x devices in FLASH mode */
+/* (that is, the FLASH is seen at 0) */
+
+ 
 
 
 /* Sections Definitions */

--- a/build/gcc/stm32.ld
+++ b/build/gcc/stm32.ld
@@ -1,10 +1,10 @@
-/*
-Linker script for STM32F10x
-Copyright RAISONANCE 2007 (modified by Lanchon 1-Feb-2008)
-You can use, copy and distribute this file freely, but without any waranty.
-Configure memory sizes, end of stack and boot mode for your project here.
-*/
-
+/* 
+ * Copyright RAISONANCE 2007 (modified by Lanchon 1-Feb-2008)
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Linker script for STM32F10x
+ * Configure memory sizes, end of stack and boot mode for your project here.
+ */
 
 /* include the common STM32F10x sub-script */
 INCLUDE "./STM32_COMMON.ld"


### PR DESCRIPTION
I've added in SPDX-License-Identifier tags and removed misspelled and inconsistent headers in an effort to remove any ambiguity concerning licensing rights.