### PR TITLE
detect and support GD32(hw_rev5)

### DIFF
--- a/src/hw_config_rev4.c
+++ b/src/hw_config_rev4.c
@@ -203,11 +203,15 @@ HardwareDefinitionPtr detect_hardware(void) {
 //    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
 //    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
 //    GPIO_Init (GPIOB, &GPIO_InitStructure);
-
+    #define CPU_MODEL_GD32       (0x13030410)
+    
     const uint8_t state = GPIO_ReadInputDataBit (GPIOB, GPIO_Pin_7);
-    if (state == 0) {
+    if (*((volatile uint32_t *)0xE0042000) == CPU_MODEL_GD32) {
+        g_current_hardware = &HW3;
+    } else if(state == 0){
         g_current_hardware = &HW4;
-    } else{
+    }
+    else{
         g_current_hardware = &HW3;
     }
     return g_current_hardware;


### PR DESCRIPTION
New firmware version for the hw_rev5 which uses the GD32 instead of the STM32 because of the chip shortage:
[nitrokey-pro-firmware-v0.14-3-de6aa655.tar.gz](https://github.com/Nitrokey/nitrokey-pro-firmware/files/8756765/nitrokey-pro-firmware-v0.14-3-de6aa655.tar.gz)

I used [this](https://github.com/Nitrokey/nitrokey-pro-firmware/blob/c6a3e62708a30002956bd8714d9fb57d54ed7e9e/Dockerfile) Docker environment for building.

[Tested](https://github.com/Nitrokey/nitrokey-pro-firmware/files/8756771/NK-pro-tests-de6aa655.zip) for hw_rev5 & hw_rev3. (Test for hw_rev4 are still missing!)